### PR TITLE
Handle hash URLs, provide both `{ filename, filepath }`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: node_js
+node_js:
+  - "6"
+  - "8"
+  - "10"
+
+before_install:
+  - travis_retry npm install
+
+script:
+  - npm test
+
+matrix:
+  allow_failures:
+  - node_js: "10"

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import slugify from 'slugify';
 import URL from 'url-parse';
 
+const isHash = /^#/;
 
 /**
  * A react component that wraps [react-markdown](react-markdown) that:
@@ -74,6 +75,14 @@ export default class ReactMarkdownGithub extends Component {
   * @api private
   */
   normalizeLinkUri(url) {
+    // Do not attempt to parse "pure" hashes since they
+    // are not fully qualified URLs by definition. This will
+    // not work for querystring plus hash, but Github does not
+    // support querystring so this is by design.
+    if (isHash.test(url)) {
+      return url;
+    }
+
     var parsed = new URL(url, this.props.sourceUrl);
     return parsed.href;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -37,10 +37,12 @@ export default class ReactMarkdownGithub extends Component {
     const { origin, pathname } = new URL(url);
     const parts = pathname.split('/');
     const [, org, repo] = parts;
-    const filename = `/${parts.slice(5).join('/')}`;
+    const filepath = `/${parts.slice(5).join('/')}`;
+    const filename = parts[parts.length - 1];
 
     return {
       github: `${origin}/`,
+      filepath,
       filename,
       org,
       repo
@@ -83,9 +85,7 @@ export default class ReactMarkdownGithub extends Component {
       return url;
     }
 
-    // TODO: Remove this and set this value in normalizeGithubUrl
-    const realFile = this.state.filename.replace(/^\//, '');
-    const withinFile = new RegExp(`\.?\/?${realFile}#(.*)$`, 'i');
+    const withinFile = new RegExp(`.?/?${this.state.filename}#(.*)$`, 'i');
     const parsed = new URL(url, this.props.sourceUrl);
     const isWithinFile = withinFile.test(url);
 
@@ -135,7 +135,6 @@ export default class ReactMarkdownGithub extends Component {
   * @api private
   */
   renderHeading(props) {
-
     let title = '';
 
     props.children.forEach((child) => {
@@ -184,7 +183,7 @@ export default class ReactMarkdownGithub extends Component {
         className={ className }
         resolver={ resolver }
         transformLinkUri={ this.transformLinkUri }
-        transformImageUri={ this.transformImageUri  } />
+        transformImageUri={ this.transformImageUri } />
     );
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -83,8 +83,15 @@ export default class ReactMarkdownGithub extends Component {
       return url;
     }
 
-    var parsed = new URL(url, this.props.sourceUrl);
-    return parsed.href;
+    // TODO: Remove this and set this value in normalizeGithubUrl
+    const realFile = this.state.filename.replace(/^\//, '');
+    const withinFile = new RegExp(`\.?\/?${realFile}#(.*)$`, 'i');
+    const parsed = new URL(url, this.props.sourceUrl);
+    const isWithinFile = withinFile.test(url);
+
+    return isWithinFile
+      ? parsed.hash
+      : parsed.href;
   }
 
   /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -168,7 +168,7 @@ Repeat Header`;
       assume(tree.find('a').prop('href')).is.equal(href);
     }
 
-    it.only('does not transform anchors links (simple anchor)', () => {
+    it('does not transform anchors links (simple anchor)', () => {
       const input = `
 ## Table of Contents
 
@@ -186,10 +186,10 @@ Repeat Header`;
 
       const anchors = tree.find('a');
       assume(anchors).to.have.length(5);
-      assume(anchors.at(1).prop('href')).is.equal('#hey-that-is-cool')
-      assume(anchors.at(2).prop('href')).is.equal('#nested-anchor')
-      assume(anchors.at(3).prop('href')).is.equal('#anchor-reference')
-      assume(anchors.at(4).prop('href')).is.equal('#nested-three-space-anchor')
+      assume(anchors.at(1).prop('href')).is.equal('#hey-that-is-cool');
+      assume(anchors.at(2).prop('href')).is.equal('#nested-anchor');
+      assume(anchors.at(3).prop('href')).is.equal('#anchor-reference');
+      assume(anchors.at(4).prop('href')).is.equal('#nested-three-space-anchor');
     });
 
     it('does not transform absolute links', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -168,6 +168,30 @@ Repeat Header`;
       assume(tree.find('a').prop('href')).is.equal(href);
     }
 
+    it.only('does not transform anchors links (simple anchor)', () => {
+      const input = `
+## Table of Contents
+
+- [Hey that is cool](#hey-that-is-cool)
+  - [Nested anchor](#nested-anchor)
+- [Anchor reference][anchor-ref]
+   - [Nested three-space anchor](#nested-three-space-anchor)
+
+[anchor-ref]: #anchor-reference
+`;
+
+      renderFullDom({ source: input });
+
+      assume(tree.find('#table-of-contents')).to.have.length(1);
+
+      const anchors = tree.find('a');
+      assume(anchors).to.have.length(5);
+      assume(anchors.at(1).prop('href')).is.equal('#hey-that-is-cool')
+      assume(anchors.at(2).prop('href')).is.equal('#nested-anchor')
+      assume(anchors.at(3).prop('href')).is.equal('#anchor-reference')
+      assume(anchors.at(4).prop('href')).is.equal('#nested-three-space-anchor')
+    });
+
     it('does not transform absolute links', () => {
       const input = `[I'm an inline-style link](https://www.google.com)`;
       renderDomWithResolver(input);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -95,6 +95,18 @@ describe('ReactMarkdownGithub', function () {
       assume(result.filename).is.equal('README.md');
       assume(result.filepath).is.equal('/README.md');
     });
+
+    it('should provide distinct { filename, filepath }', () => {
+      const uri = 'http://github.com/godaddy/react-markdown-github/blob/master/nested/dir/README.md';
+      const result = ReactMarkdownGithub.normalizeGithubUrl(uri);
+
+      assume(result).is.an('object');
+      assume(result.github).is.equal('http://github.com/');
+      assume(result.org).is.equal('godaddy');
+      assume(result.filename).is.equal('README.md');
+      assume(result.filepath).is.equal('/nested/dir/README.md');
+    });
+
   });
 
   describe('renderers', function () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -81,7 +81,8 @@ describe('ReactMarkdownGithub', function () {
       assume(result.github).is.equal('http://github.com/');
       assume(result.org).is.equal('godaddy');
       assume(result.repo).is.equal('react-markdown-github');
-      assume(result.filename).is.equal('/README.md');
+      assume(result.filename).is.equal('README.md');
+      assume(result.filepath).is.equal('/README.md');
     });
 
     it('should handle URLs with hash', () => {
@@ -91,8 +92,8 @@ describe('ReactMarkdownGithub', function () {
       assume(result).is.an('object');
       assume(result.github).is.equal('http://github.com/');
       assume(result.org).is.equal('godaddy');
-      assume(result.repo).is.equal('react-markdown-github');
-      assume(result.filename).is.equal('/README.md');
+      assume(result.filename).is.equal('README.md');
+      assume(result.filepath).is.equal('/README.md');
     });
   });
 


### PR DESCRIPTION
This PR does the following:

- [x] Adds `.travis.yml` and enables TravisCI
- [x] Adds support for `{ filename, filepath }` in `normalizeGithubUrl` (vs. simply `{ filename }`).
- [x] Fixes support for hash URLs in links relative to the `sourceUrl`. 