### PR TITLE
[fix] reset slug counts before rendering to prevent inconsistent anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `react-markdown-github`
 
+- [#9] Reset slug counts before rendering to prevent inconsistent anchors
+
 ### 3.0.1
 
 - [#8] Add ReactMarkdownGithub component as a default export
@@ -35,3 +37,4 @@
 [#5]: https://github.com/godaddy/react-markdown-github/pull/5
 [#4]: https://github.com/godaddy/react-markdown-github/pull/4
 [#8]: https://github.com/godaddy/react-markdown-github/pull/8
+[#9]: https://github.com/godaddy/react-markdown-github/pull/9

--- a/src/component.js
+++ b/src/component.js
@@ -166,7 +166,7 @@ export default class ReactMarkdownGithub extends Component {
       heading: this.renderHeading,
       ...this.props.renderers
     };
-    // this.slugify.reset();
+    this.slugify.reset();
     return (
       <ReactMarkdown
         { ...this.props }

--- a/src/component.js
+++ b/src/component.js
@@ -166,7 +166,7 @@ export default class ReactMarkdownGithub extends Component {
       heading: this.renderHeading,
       ...this.props.renderers
     };
-
+    // this.slugify.reset();
     return (
       <ReactMarkdown
         { ...this.props }

--- a/test/component.test.js
+++ b/test/component.test.js
@@ -156,6 +156,22 @@ Repeat Header`;
       assume(tree.find('#blort')).to.have.length(0);
     });
 
+
+    it('Headers do not increment on update', () => {
+      const input = `
+# Header
+# Header
+`;
+
+      renderFullDom({ source: input });
+      assume(tree.find('#header')).to.have.length(1);
+      assume(tree.find('#header-1')).to.have.length(1);
+
+      tree.update();
+
+      assume(tree.find('#header-2')).to.have.length(0);
+    });
+
     it('A header with code elements', () => {
       const input = '### a `codething` in the header `moreCode` txt';
 

--- a/test/component.test.js
+++ b/test/component.test.js
@@ -157,17 +157,16 @@ Repeat Header`;
     });
 
 
-    it('Headers do not increment on update', () => {
+    it('Does not increment anchors on re-render', () => {
       const input = `
 # Header
 # Header
 `;
-
       renderFullDom({ source: input });
       assume(tree.find('#header')).to.have.length(1);
       assume(tree.find('#header-1')).to.have.length(1);
 
-      tree.update();
+      tree.setProps(input);
 
       assume(tree.find('#header-2')).to.have.length(0);
     });

--- a/test/component.test.js
+++ b/test/component.test.js
@@ -165,10 +165,12 @@ Repeat Header`;
       renderFullDom({ source: input });
       assume(tree.find('#header')).to.have.length(1);
       assume(tree.find('#header-1')).to.have.length(1);
+      assume(tree.find('#header-2')).to.have.length(0);
 
       tree.setProps(input);
-
       assume(tree.find('#header-2')).to.have.length(0);
+      assume(tree.find('#header-1')).to.have.length(1);
+      assume(tree.find('#header')).to.have.length(1);
     });
 
     it('A header with code elements', () => {


### PR DESCRIPTION
It appears that re-rendering the component causes header anchor tags to be incremented.  This should not happen as anchor tags should be consistent. 

> ~Note: I am working on adding a test to cover the use case, but am struggling to get it working.~
It is working now!  